### PR TITLE
Few erros fixed on the recognition of operators.

### DIFF
--- a/support/ECLiPSe Prolog.YAML-tmLanguage
+++ b/support/ECLiPSe Prolog.YAML-tmLanguage
@@ -96,7 +96,7 @@ repository:
     - name: keyword.control.cut.prolog
       match: '!'
     - name: keyword.operator.prolog
-      match: (\s(is)\s)|=:=|==|=|\\\+|>|<|\+|\*|\-
+      match: (\s(is)\s)|=:=|=?\\?=|\\\+|@?>|@?=?<|\+|\*|\-
     - name: keyword.operator.prolog.eclipse
       match: (#|&|\$)(<|>|=)|(#|&|\$)?(::)|\.\.|or|and|neg
 

--- a/support/ECLiPSe Prolog.tmLanguage
+++ b/support/ECLiPSe Prolog.tmLanguage
@@ -270,7 +270,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(\s(is)\s)|=:=|==|=|\\\+|&gt;|&lt;|\+|\*|\-</string>
+					<string>(\s(is)\s)|=:=|=?\\?=|\\\+|@?&gt;|@?=?&lt;|\+|\*|\-</string>
 					<key>name</key>
 					<string>keyword.operator.prolog</string>
 				</dict>

--- a/support/Prolog.YAML-tmLanguage
+++ b/support/Prolog.YAML-tmLanguage
@@ -133,7 +133,7 @@ repository:
     - name: keyword.control.cut.prolog
       match: '!'
     - name: keyword.operator.prolog
-      match: (\s(is)\s)|=:=|==|=|\\\+|>|<|\+|\*|\-
+      match: (\s(is)\s)|=:=|=?\\?=|\\\+|@?>|@?=?<|\+|\*|\-
 
   variable:
     patterns:

--- a/support/Prolog.tmLanguage
+++ b/support/Prolog.tmLanguage
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>comment</key>
@@ -408,7 +408,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(\s(is)\s)|=:=|==|=|\\\+|&gt;|&lt;|\+|\*|\-</string>
+					<string>(\s(is)\s)|=:=|=?\\?=|\\\+|@?&gt;|@?=?&lt;|\+|\*|\-</string>
 					<key>name</key>
 					<string>keyword.operator.prolog</string>
 				</dict>


### PR DESCRIPTION
While working on the ECLiPSe Prolog syntax I found that some operator were not recognized:
It concerns the different operator `\=` and some term comparisons like `@<=`.
This corrects it.
