### PR TITLE
Correct package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ ERROR:         main/0
 ### Installation via Sublime Package Control ###
 
 I recommend using the [Sublime Package Control] [1] to install this package. 
-This way is much more convenient. It is named *Prolog syntax highlighting* 
-there, as well.
+This way is much more convenient. It is named *Prolog*.
 
 [1]: http://wbond.net/sublime_packages/package_control
 


### PR DESCRIPTION
The package is named [Prolog](https://packagecontrol.io/packages/Prolog) in Package Control, and not *Prolog syntax highlighting*.