### PR TITLE
More file extensions, var names starting w/underscore (#1)

### DIFF
--- a/support/Prolog.YAML-tmLanguage
+++ b/support/Prolog.YAML-tmLanguage
@@ -4,7 +4,7 @@ comment: This Source Code Form is subject to the terms of the Mozilla Public Lic
   one at http://mozilla.org/MPL/2.0/.
 name: SWI-Prolog
 scopeName: source.prolog
-fileTypes: [pl, pro]
+fileTypes: [pl, pro, prolog, swiplrc]
 uuid: df89928b-6612-475a-b414-f319d9b98664
 
 patterns:
@@ -138,6 +138,6 @@ repository:
   variable:
     patterns:
     - name: variable.parameter.uppercase.prolog
-      match: (?<![a-zA-Z0-9_])[A-Z][a-zA-Z0-9_]*
+      match: (?<![a-zA-Z0-9_])[_A-Z][a-zA-Z0-9_]*
     - name: variable.language.anonymous.prolog
       match: (?<!\w)_

--- a/support/Prolog.tmLanguage
+++ b/support/Prolog.tmLanguage
@@ -8,6 +8,8 @@
 	<array>
 		<string>pl</string>
 		<string>pro</string>
+		<string>prolog</string>
+		<string>swiplrc</string>
 	</array>
 	<key>name</key>
 	<string>SWI-Prolog</string>
@@ -420,7 +422,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>(?&lt;![a-zA-Z0-9_])[A-Z][a-zA-Z0-9_]*</string>
+					<string>(?&lt;![a-zA-Z0-9_])[_A-Z][a-zA-Z0-9_]*</string>
 					<key>name</key>
 					<string>variable.parameter.uppercase.prolog</string>
 				</dict>


### PR DESCRIPTION
1. Allow for `.prolog` and `.swiplrc` file extensions.
2. Support variable names starting with underscore (e.g. `_some_var`).